### PR TITLE
Fix "UnsupportedOperation" error

### DIFF
--- a/tusfilter.py
+++ b/tusfilter.py
@@ -566,7 +566,7 @@ class TusFilter(object):
         if cur_length != -1 and length != cur_length:
             raise ConflictUploadLengthError()
 
-        body = env.req.body_file
+        body = env.req.body_file_seekable
         with open(fpath, 'ab+') as f:
             f.seek(0, os.SEEK_END)
             body.seek(0)


### PR DESCRIPTION
The error occurs running on flask dev server (flask + python2.7) and probably some other envs

```
File ".../venv/lib/python2.7/site-packages/tusfilter.py", line 572, in write_data
    body.seek(0)
UnsupportedOperation: seek
```

This MR fixes that with update from [JokerQyou](https://github.com/easydo-cn/tusfilter/pull/8)