### PR TITLE
Use body_file_seekable

### DIFF
--- a/tusfilter.py
+++ b/tusfilter.py
@@ -566,7 +566,7 @@ class TusFilter(object):
         if cur_length != -1 and length != cur_length:
             raise ConflictUploadLengthError()
 
-        body = env.req.body_file
+        body = env.req.body_file_seekable
         with open(fpath, 'ab+') as f:
             f.seek(0, os.SEEK_END)
             body.seek(0)


### PR DESCRIPTION
Hey there, I just recently found this middleware and it's working pretty well for us, except for this little issue.

Using `body_file_seekable` is recommended in the [webob
docs](https://docs.pylonsproject.org/projects/webob/en/stable/api/request.html#webob.request.BaseRequest.body_file_seekable)
and prevents
```
  File "/home/runner/work/galaxy/galaxy/galaxy root/.venv/lib/python3.7/site-packages/tusfilter.py", line 213, in __call__
    self.handle(env)
  File "/home/runner/work/galaxy/galaxy/galaxy root/.venv/lib/python3.7/site-packages/tusfilter.py", line 250, in handle
    self.patch(env)
  File "/home/runner/work/galaxy/galaxy/galaxy root/.venv/lib/python3.7/site-packages/tusfilter.py", line 316, in patch
    current_offset = self.write_data(env)
  File "/home/runner/work/galaxy/galaxy/galaxy root/.venv/lib/python3.7/site-packages/tusfilter.py", line 571, in write_data
    body.seek(0)
io.UnsupportedOperation: File or stream is not seekable.
```